### PR TITLE
Reoute modification.

### DIFF
--- a/router/__init__.py
+++ b/router/__init__.py
@@ -2,6 +2,6 @@ from utils.api import Router
 from .activity_registration import router as registration_router
 
 router = Router()
-router.include_router(registration_router, "/activity_registration")
+router.include_router(registration_router, "/activity-registration")
 
 __all__ = ["router"]


### PR DESCRIPTION
This pull request includes a small change to the `router/__init__.py` file. The change modifies the URL path for the `registration_router` to use hyphens instead of underscores.

* [`router/__init__.py`](diffhunk://#diff-b4dbaace8ef74fe84717a8932062e85c956f485809802b155d18f39eee3f03ceL5-R5): Changed the URL path for `registration_router` from `/activity_registration` to `/activity-registration`.