### PR TITLE
Unregistration endpoint

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -5,7 +5,7 @@ from schemas.plugin_setting import PluginSetting
 
 logger = logging.getLogger("coffeebreak.activity-registration")
 
-PLUGIN_TITLE = "Activities Registration"
+PLUGIN_TITLE = "registration-system-plugin"
 PLUGIN_DESCRIPTION = "This plugin allows managing user registrations for activities with defined limits."
 
 async def register_plugin():

--- a/__init__.py
+++ b/__init__.py
@@ -4,10 +4,10 @@ import logging
 logger = logging.getLogger("coffeebreak.plugins.activity_registration")
 
 def register_plugin():
-    print("Activity registration plugin loaded.")
+    logger.debug("Activity registration plugin loaded.")
 
 def unregister_plugin():
-    print("Activity registration plugin unloaded.")
+    logger.debug("Activity registration plugin unloaded.")
 
 REGISTER = register_plugin
 UNREGISTER = unregister_plugin

--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,7 @@
 from .router import router
+import logging
+
+logger = logging.getLogger("coffeebreak.plugins.activity_registration")
 
 def register_plugin():
     print("Activity registration plugin loaded.")

--- a/__init__.py
+++ b/__init__.py
@@ -3,7 +3,7 @@ import logging
 from services.ui.plugin_settings import create_plugin_setting, delete_plugin_setting_by_title
 from schemas.plugin_setting import PluginSetting
 
-logger = logging.getLogger("coffeebreak.plugins.activity_registration")
+logger = logging.getLogger("coffeebreak.activity-registration")
 
 PLUGIN_TITLE = "Activities Registration"
 PLUGIN_DESCRIPTION = "This plugin allows managing user registrations for activities with defined limits."

--- a/__init__.py
+++ b/__init__.py
@@ -1,13 +1,31 @@
 from .router import router
 import logging
+from services.ui.plugin_settings import create_plugin_setting, delete_plugin_setting_by_title
+from schemas.plugin_setting import PluginSetting
 
 logger = logging.getLogger("coffeebreak.plugins.activity_registration")
 
-def register_plugin():
+PLUGIN_TITLE = "Activities Registration"
+PLUGIN_DESCRIPTION = "This plugin allows managing user registrations for activities with defined limits."
+
+async def register_plugin():
     logger.debug("Activity registration plugin loaded.")
 
-def unregister_plugin():
+    setting = PluginSetting(
+        title=PLUGIN_TITLE,
+        description=PLUGIN_DESCRIPTION,
+        inputs=[]
+    )
+    await create_plugin_setting(setting)
+
+    return router
+
+async def unregister_plugin():
     logger.debug("Activity registration plugin unloaded.")
+    await delete_plugin_setting_by_title(PLUGIN_TITLE)
 
 REGISTER = register_plugin
 UNREGISTER = unregister_plugin
+
+SETTINGS = {}
+DESCRIPTION = PLUGIN_DESCRIPTION

--- a/router/activity_registration.py
+++ b/router/activity_registration.py
@@ -14,7 +14,8 @@ from ..schemas.activity_registration import (
     ActivityMetadata as ActivityMetadataSchema,
     ActivityMetadataUpdate,
     ActivityRegistration as ActivityRegistrationSchema,
-    SlotAvailability
+    SlotAvailability,
+    DeregistrationResponse
 )
 
 router = Router()
@@ -62,6 +63,24 @@ def register_user(
     db.commit()
     db.refresh(registration)
     return registration
+
+from ..schemas.activity_registration import DeregistrationResponse
+
+@router.delete("/register/{activity_id}", response_model=DeregistrationResponse)
+def deregister_user(
+    activity_id: int = Path(...),
+    db: Session = Depends(get_db),
+    user: dict = Depends(get_current_user)
+):
+    user_id = user["sub"]
+
+    registration = db.query(ActivityRegistrationModel).filter_by(user_id=user_id, activity_id=activity_id).first()
+    if not registration:
+        raise HTTPException(status_code=404, detail="No registration found for this activity.")
+
+    db.delete(registration)
+    db.commit()
+    return {"activity_id": activity_id, "user_id": user_id}
 
 @router.get("/metadata/{activity_id}", response_model=ActivityMetadataSchema)
 def get_metadata(

--- a/router/activity_registration.py
+++ b/router/activity_registration.py
@@ -64,9 +64,7 @@ def register_user(
     db.refresh(registration)
     return registration
 
-from ..schemas.activity_registration import DeregistrationResponse
-
-@router.delete("/register/{activity_id}", response_model=DeregistrationResponse)
+@router.delete("/deregister/{activity_id}", response_model=DeregistrationResponse)
 def deregister_user(
     activity_id: int = Path(...),
     db: Session = Depends(get_db),

--- a/schemas/activity_registration.py
+++ b/schemas/activity_registration.py
@@ -32,3 +32,7 @@ class SlotAvailability(BaseModel):
     total_slots: Optional[int] = None
     registered: Optional[int] = None
     message: Optional[str] = None
+
+class DeregistrationResponse(BaseModel):
+    activity_id: int
+    user_id: str


### PR DESCRIPTION
This pull request includes several significant changes to the activity registration plugin, primarily focusing on logging improvements, plugin settings management, and the addition of a new deregistration endpoint.

### Improvements and new features:

* [`__init__.py`](diffhunk://#diff-8e2c1f727276d30ced72fa67cb848772a9802162bec39b42a8df5359fd063a4cR2-R31): Added logging for plugin load and unload events, and implemented asynchronous functions to create and delete plugin settings (`[__init__.pyR2-R31](diffhunk://#diff-8e2c1f727276d30ced72fa67cb848772a9802162bec39b42a8df5359fd063a4cR2-R31)`).
* [`router/activity_registration.py`](diffhunk://#diff-0f531c6b40b4a6db72b1d7167d267431dcac9fcabe775521daf74174761ae1dfR67-R82): Introduced a new endpoint to deregister users from activities, including necessary error handling (`[router/activity_registration.pyR67-R82](diffhunk://#diff-0f531c6b40b4a6db72b1d7167d267431dcac9fcabe775521daf74174761ae1dfR67-R82)`).
* [`schemas/activity_registration.py`](diffhunk://#diff-209ba8f161571e199b9f6500ec930ff97d417c2bbd521490b467ad8b9c0a2ea1R35-R38): Added a new schema class `DeregistrationResponse` to structure the response for the deregistration endpoint (`[schemas/activity_registration.pyR35-R38](diffhunk://#diff-209ba8f161571e199b9f6500ec930ff97d417c2bbd521490b467ad8b9c0a2ea1R35-R38)`).

### Code enhancements:

* [`router/activity_registration.py`](diffhunk://#diff-0f531c6b40b4a6db72b1d7167d267431dcac9fcabe775521daf74174761ae1dfL17-R18): Updated import statements to include the new `DeregistrationResponse` schema (`[router/activity_registration.pyL17-R18](diffhunk://#diff-0f531c6b40b4a6db72b1d7167d267431dcac9fcabe775521daf74174761ae1dfL17-R18)`).