### PR TITLE
feat: add plugin SDK integration, i18n support, and backend implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,6 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# Build output
+.build/

--- a/.talismanrc
+++ b/.talismanrc
@@ -1,0 +1,7 @@
+fileignoreconfig:
+- filename: models/activity_registration.py
+  checksum: 8a945be9bc9be5242a674bc80eb72a4160bcf5720dbb6740be6ee528b095cfad
+- filename: admin/Page.jsx
+  checksum: ac01c45a37ea0382cbfb7945ed75fca70084d30bbb899e7931dc8421635f6fe9
+- filename: .build/pages/registration-system-plugin.mjs
+  checksum: 93397e2fca1133feafce940ee087121ce81db7652a31733279cae35518603dea

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,19 @@
+from .router import router
+from .models import ActivityRegistrationMetadata, ActivityRegistration
+
+
+def REGISTER():
+    pass
+
+
+def UNREGISTER():
+    pass
+
+
+__all__ = [
+    "router",
+    "ActivityRegistrationMetadata",
+    "ActivityRegistration",
+    "REGISTER",
+    "UNREGISTER",
+]

--- a/admin/Page.jsx
+++ b/admin/Page.jsx
@@ -1,0 +1,311 @@
+import { useState, useEffect } from "react";
+import { useApi, baseUrl, registerPluginTranslations } from "coffeebreak";
+import { useActivities, useNotification, useMedia } from "coffeebreak/contexts";
+import { useTranslation } from "react-i18next";
+import { FaSearch, FaEdit, FaExclamationTriangle, FaTrash } from "react-icons/fa";
+import en from "../locales/en.json";
+import ptBR from "../locales/pt-BR.json";
+import ptPT from "../locales/pt-PT.json";
+
+const NS = "registration-system-plugin";
+registerPluginTranslations(NS, { en, "pt-BR": ptBR, "pt-PT": ptPT });
+
+const apiBase = `${baseUrl}/registration-system-plugin/activity-registration`;
+
+// --- Shared UI ---
+
+function DeleteModal({ isOpen, onClose, onConfirm, isLoading, title, message }) {
+  if (!isOpen) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+      <div className="bg-base-100 rounded-xl shadow-xl max-w-md w-full p-6">
+        <h3 className="font-bold text-lg mb-4">{title}</h3>
+        <div className="flex items-center gap-3 mb-4">
+          <div className="text-primary"><FaExclamationTriangle size={24} /></div>
+          <p>{message}</p>
+        </div>
+        <div className="flex justify-end gap-3 mt-6">
+          <button className="btn btn-ghost" onClick={onClose} disabled={isLoading}>Cancel</button>
+          <button className="btn btn-primary" onClick={onConfirm} disabled={isLoading}>
+            {isLoading ? <span className="loading loading-spinner loading-sm" /> : "Delete"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// --- ActivityCard: displays a single activity with edit button ---
+
+function ActivityCard({ activity, onEdit }) {
+  const { t } = useTranslation(NS);
+  const { getMediaUrl } = useMedia();
+  const meta = activity.metadata;
+
+  const imageUrl = activity.image
+    ? (activity.image.startsWith("http") ? activity.image : getMediaUrl(activity.image))
+    : null;
+
+  return (
+    <div className="group card bg-base-100 shadow-sm hover:shadow-lg transition-all duration-300 border-2 border-secondary hover:border-primary overflow-hidden h-[380px]">
+      <div className="absolute top-2 right-2 z-10">
+        <button
+          className="p-2 bg-base-100/90 hover:bg-white text-base-content/60 hover:text-primary rounded-lg shadow-sm border border-transparent hover:border-primary/20"
+          onClick={() => onEdit(activity.id)}
+          aria-label={t("activities.edit")}
+          type="button"
+        >
+          <FaEdit className="w-4 h-4" />
+        </button>
+      </div>
+
+      <div className="h-40 w-full overflow-hidden bg-base-200 relative shrink-0">
+        {imageUrl ? (
+          <img src={imageUrl} alt={t("activities.imageAlt")} className="w-full h-full object-cover" />
+        ) : (
+          <div className="w-full h-full bg-base-200/50 flex items-center justify-center">
+            <span className="text-base-content/40 text-sm italic">{t("activities.noImage")}</span>
+          </div>
+        )}
+        {activity.type && (
+          <div className="absolute bottom-3 left-3">
+            <span className="badge border-none shadow-sm font-semibold px-3 py-3" style={{ backgroundColor: activity.type?.color || "var(--color-primary)", color: "#fff" }}>
+              {activity.type?.type || activity.type}
+            </span>
+          </div>
+        )}
+      </div>
+
+      <div className="card-body p-5 gap-1 shrink-0 h-[220px]">
+        <h2 className="card-title text-lg font-bold text-primary line-clamp-1">{activity.name}</h2>
+        {activity.topic && (
+          <span className="badge badge-outline badge-sm text-xs opacity-70">{activity.topic}</span>
+        )}
+        <p className="text-sm text-base-content/80 line-clamp-3 leading-relaxed min-h-[4.5em]">
+          {activity.description || <span className="italic opacity-50">{t("activities.noDescription")}</span>}
+        </p>
+        <div className="mt-auto pt-3 flex items-center border-t border-base-200">
+          {meta?.is_restricted ? (
+            <span className={`flex items-center gap-1.5 text-xs font-semibold ${meta.registered >= meta.slots ? "text-error" : "text-success"}`}>
+              <span className={`w-2 h-2 rounded-full ${meta.registered >= meta.slots ? "bg-error" : "bg-success"}`} />
+              {meta.registered} / {meta.slots} {t("activities.slots.label", "Slots")}
+            </span>
+          ) : (
+            <span className="flex items-center gap-1.5 text-xs text-base-content/50">
+              <span className="w-2 h-2 rounded-full bg-base-300" />
+              {t("activities.slots.open", "Open Access")}
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// --- EditMetadataModal: self-contained, uses useApi + useNotification ---
+
+function EditMetadataModal({ activityId, activityName, onUpdate, onClose }) {
+  const api = useApi();
+  const { showNotification } = useNotification();
+  const { t } = useTranslation(NS);
+
+  const [isRestricted, setIsRestricted] = useState(false);
+  const [slots, setSlots] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMsg, setErrorMsg] = useState("");
+
+  useEffect(() => {
+    if (activityId) fetchMetadata();
+  }, [activityId]);
+
+  const fetchMetadata = async () => {
+    setIsLoading(true);
+    try {
+      const { data } = await api.get(`${apiBase}/metadata/${activityId}`);
+      setIsRestricted(data.is_restricted);
+      setSlots(data.slots ?? "");
+      setErrorMsg("");
+    } catch {
+      setIsRestricted(false);
+      setSlots("");
+      setErrorMsg(t("activities.slots.noMetadataInfo"));
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleSave = async (e) => {
+    e.preventDefault();
+    const parsedSlots = Number.parseInt(slots, 10);
+    const params = { is_restricted: isRestricted };
+    if (isRestricted) params.slots = Number.isNaN(parsedSlots) ? undefined : parsedSlots;
+
+    try {
+      await api.post(`${apiBase}/metadata/${activityId}`, null, { params });
+      showNotification(t("activities.slots.saveSuccess"), "success");
+      await onUpdate(activityId);
+      onClose();
+    } catch (err) {
+      console.error(err);
+      showNotification(t("activities.slots.saveError"), "error");
+    }
+  };
+
+  if (!activityId) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+      <div className="bg-base-100 rounded-xl shadow-xl max-w-xl w-full p-6">
+        <button className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2" type="button" onClick={onClose}>✕</button>
+        <h3 className="font-bold text-lg mb-1">{t("activities.slots.modalTitle")}</h3>
+        {activityName && <p className="text-sm font-bold text-secondary mb-4">{activityName}</p>}
+        {errorMsg && (
+          <div className="alert alert-info mb-4">
+            <FaExclamationTriangle className="h-5 w-5" />
+            <span>{errorMsg}</span>
+          </div>
+        )}
+        <form onSubmit={handleSave}>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 items-center mb-6">
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={isRestricted}
+                onChange={(e) => { setIsRestricted(e.target.checked); setErrorMsg(""); }}
+                className="checkbox checkbox-primary"
+              />
+              <span className="label-text">{t("activities.slots.limitLabel")}</span>
+            </label>
+            <input
+              type="number"
+              className="input input-bordered w-full"
+              value={isRestricted ? slots : ""}
+              onChange={(e) => setSlots(e.target.value)}
+              placeholder={t("activities.slots.slotPlaceholder")}
+              disabled={!isRestricted}
+              min={0}
+            />
+          </div>
+          <div className="modal-action">
+            <button type="submit" className="btn btn-primary" disabled={isLoading}>
+              {isLoading ? <span className="loading loading-spinner" /> : t("common.actions.save")}
+            </button>
+            <button type="button" className="btn" onClick={onClose}>{t("common.actions.cancel")}</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+// --- Main page ---
+
+export default function ActivitySlotsPage() {
+  const api = useApi();
+  const { activities, fetchActivities, getActivityType } = useActivities();
+  const { t } = useTranslation(NS);
+
+  const [activityData, setActivityData] = useState({});
+  const [selectedActivityId, setSelectedActivityId] = useState(null);
+  const [isLoadingData, setIsLoadingData] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      setIsLoadingData(true);
+      await fetchActivities();
+      setIsLoadingData(false);
+    };
+    load();
+  }, []);
+
+  useEffect(() => {
+    if (activities.length > 0) {
+      fetchAllMetadata(activities.map((a) => a.id));
+    }
+  }, [activities]);
+
+  const fetchAllMetadata = async (ids) => {
+    const result = {};
+    await Promise.all(
+      ids.map(async (id) => {
+        try {
+          const [metadataRes, slotsRes] = await Promise.all([
+            api.get(`${apiBase}/metadata/${id}`),
+            api.get(`${apiBase}/register/${id}/available-slots/`),
+          ]);
+          result[id] = {
+            is_restricted: metadataRes.data.is_restricted,
+            slots: metadataRes.data.slots,
+            registered: slotsRes.data.registered,
+          };
+        } catch {
+          result[id] = null;
+        }
+      }),
+    );
+    setActivityData(result);
+  };
+
+  const handleMetadataUpdate = async (activityId) => {
+    try {
+      const [metadataRes, slotsRes] = await Promise.all([
+        api.get(`${apiBase}/metadata/${activityId}`),
+        api.get(`${apiBase}/register/${activityId}/available-slots/`),
+      ]);
+      setActivityData((prev) => ({
+        ...prev,
+        [activityId]: {
+          is_restricted: metadataRes.data.is_restricted,
+          slots: metadataRes.data.slots,
+          registered: slotsRes.data.registered,
+        },
+      }));
+    } catch (err) {
+      console.error("Error:", err);
+    }
+  };
+
+  const mappedActivities = activities.map((activity) => ({
+    ...activity,
+    type: getActivityType(activity.type_id),
+    metadata: activityData[activity.id],
+  }));
+
+  const selectedActivity = activities.find((a) => a.id === selectedActivityId);
+
+  return (
+    <div className="w-full min-h-svh p-4 lg:p-8">
+      <h1 className="text-3xl font-bold mb-6">{t("activities.editSlotsTitle")}</h1>
+
+      {isLoadingData ? (
+        <div className="flex justify-center items-center h-64">
+          <span className="loading loading-spinner loading-lg" />
+        </div>
+      ) : mappedActivities.length === 0 ? (
+        <div className="text-center py-12">
+          <FaSearch className="mx-auto text-4xl text-gray-400 mb-4" />
+          <p className="text-2xl text-gray-500">{t("activities.noActivities")}</p>
+        </div>
+      ) : (
+        <div className="w-full grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 mt-6">
+          {mappedActivities.map((activity) => (
+            <ActivityCard
+              key={activity.id}
+              activity={activity}
+              onEdit={(id) => setSelectedActivityId(id)}
+            />
+          ))}
+        </div>
+      )}
+
+      {selectedActivityId && (
+        <EditMetadataModal
+          activityId={selectedActivityId}
+          activityName={selectedActivity?.name}
+          onUpdate={handleMetadataUpdate}
+          onClose={() => setSelectedActivityId(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,26 @@
+{
+  "activities": {
+    "editSlotsTitle": "Manage Activity Registration",
+    "noActivities": "No activities found",
+    "noDescription": "No description",
+    "edit": "Edit activity",
+    "imageAlt": "Activity image",
+    "noImage": "No image",
+    "slots": {
+      "modalTitle": "Registration Slots",
+      "label": "Slots: {{count}}",
+      "open": "Open",
+      "limitLabel": "Slot limit",
+      "slotPlaceholder": "e.g. 100",
+      "noMetadataInfo": "No slot configuration available for this activity.",
+      "saveSuccess": "Slots saved successfully",
+      "saveError": "Failed to save slots"
+    }
+  },
+  "common": {
+    "actions": {
+      "save": "Save",
+      "cancel": "Cancel"
+    }
+  }
+}

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -1,0 +1,26 @@
+{
+  "activities": {
+    "editSlotsTitle": "Gerir Inscrições nas Atividades",
+    "noActivities": "Nenhuma atividade encontrada",
+    "noDescription": "Sem descrição",
+    "edit": "Editar atividade",
+    "imageAlt": "Imagem da atividade",
+    "noImage": "Sem imagem",
+    "slots": {
+      "modalTitle": "Vagas de Inscrição",
+      "label": "Vagas: {{count}}",
+      "open": "Aberto",
+      "limitLabel": "Limite de vagas",
+      "slotPlaceholder": "ex: 100",
+      "noMetadataInfo": "Nenhuma configuração de vagas disponível para esta atividade.",
+      "saveSuccess": "Vagas salvas com sucesso",
+      "saveError": "Falha ao salvar vagas"
+    }
+  },
+  "common": {
+    "actions": {
+      "save": "Salvar",
+      "cancel": "Cancelar"
+    }
+  }
+}

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -1,0 +1,26 @@
+{
+  "activities": {
+    "editSlotsTitle": "Gerir Inscrições nas Atividades",
+    "noActivities": "Nenhuma atividade encontrada",
+    "noDescription": "Sem descrição",
+    "edit": "Editar atividade",
+    "imageAlt": "Imagem da atividade",
+    "noImage": "Sem imagem",
+    "slots": {
+      "modalTitle": "Vagas de Inscrição",
+      "label": "Vagas: {{count}}",
+      "open": "Aberto",
+      "limitLabel": "Limite de vagas",
+      "slotPlaceholder": "ex: 100",
+      "noMetadataInfo": "Nenhuma configuração de vagas disponível para esta atividade.",
+      "saveSuccess": "Vagas guardadas com sucesso",
+      "saveError": "Falha ao guardar vagas"
+    }
+  },
+  "common": {
+    "actions": {
+      "save": "Guardar",
+      "cancel": "Cancelar"
+    }
+  }
+}

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,3 @@
+from .activity_registration import ActivityRegistration, ActivityRegistrationMetadata
+
+__all__ = ["ActivityRegistration", "ActivityRegistrationMetadata"]

--- a/models/activity_registration.py
+++ b/models/activity_registration.py
@@ -1,0 +1,50 @@
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    UniqueConstraint,
+)
+from sqlalchemy.sql import func
+
+from coffeebreak.db import ModelBase as Base
+
+
+class ActivityRegistrationMetadata(Base):
+    __tablename__ = "activity_registration_metadata"
+
+    id = Column(Integer, primary_key=True, index=True)
+    activity_id = Column(
+        Integer,
+        ForeignKey("activities.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    is_restricted = Column(Boolean, nullable=False, default=False)
+    slots = Column(Integer, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+
+class ActivityRegistration(Base):
+    __tablename__ = "activity_registrations"
+    __table_args__ = (
+        UniqueConstraint(
+            "activity_id", "user_id", name="uq_activity_registration_activity_user"
+        ),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    activity_id = Column(
+        Integer,
+        ForeignKey("activities.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    user_id = Column(String, nullable=False, index=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "registration-system-plugin"
+version = "0.1.0"
+dependencies = []
+
+[tool.coffeebreak]
+identifier = "registration-system-plugin"
+name = "Registration System Plugin"
+description = "Activity registration metadata and slot management plugin."
+config_page = true
+
+[tool.coffeebreak.admin_page]
+file = "admin/Page.jsx"
+route_slug = "registration-system-plugin"
+export_name = "default"

--- a/router/__init__.py
+++ b/router/__init__.py
@@ -1,0 +1,8 @@
+from coffeebreak import Router
+
+from .activity_registration import router as activity_registration_router
+
+router = Router()
+router.include_router(activity_registration_router, prefix="/activity-registration")
+
+__all__ = ["router"]

--- a/router/activity_registration.py
+++ b/router/activity_registration.py
@@ -1,0 +1,75 @@
+from fastapi import Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from coffeebreak import Router
+from coffeebreak.auth import check_role, get_current_user
+from coffeebreak.db import DB as get_db
+
+from ..schemas import (
+    ActivityRegistrationMetadataResponse,
+    ActivityRegistrationMetadataUpdate,
+    ActivityRegistrationResponse,
+    ActivityRegistrationSlotsResponse,
+)
+from ..services import ActivityRegistrationService
+
+router = Router()
+
+
+def _parse_slots(slots: str | None) -> int | None:
+    if slots is None:
+        return None
+
+    value = slots.strip()
+    if not value or value.lower() == "nan":
+        return None
+
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Invalid slots value") from exc
+
+
+@router.get(
+    "/metadata/{activity_id}", response_model=ActivityRegistrationMetadataResponse
+)
+def get_activity_metadata(activity_id: int, db: Session = Depends(get_db)):
+    return ActivityRegistrationService(db).get_metadata(activity_id)
+
+
+@router.post(
+    "/metadata/{activity_id}", response_model=ActivityRegistrationMetadataResponse
+)
+def upsert_activity_metadata(
+    activity_id: int,
+    is_restricted: bool = Query(default=False),
+    slots: str | None = Query(default=None),
+    db: Session = Depends(get_db),
+    _: dict = Depends(check_role(["manage_activities"])),
+):
+    parsed_slots = _parse_slots(slots)
+    payload = ActivityRegistrationMetadataUpdate(
+        is_restricted=is_restricted,
+        slots=parsed_slots,
+    )
+    return ActivityRegistrationService(db).upsert_metadata(
+        activity_id, payload.is_restricted, payload.slots
+    )
+
+
+@router.post("/register/{activity_id}", response_model=ActivityRegistrationResponse)
+def register_for_activity(
+    activity_id: int,
+    force_auth: bool = Query(default=True),
+    db: Session = Depends(get_db),
+    user: dict | None = Depends(get_current_user(force_auth=False)),
+):
+    return ActivityRegistrationService(db).register(activity_id, user, force_auth)
+
+
+@router.get(
+    "/register/{activity_id}/available-slots/",
+    response_model=ActivityRegistrationSlotsResponse,
+)
+def get_available_slots(activity_id: int, db: Session = Depends(get_db)):
+    return ActivityRegistrationService(db).get_available_slots(activity_id)

--- a/schemas/__init__.py
+++ b/schemas/__init__.py
@@ -1,0 +1,13 @@
+from .activity_registration import (
+    ActivityRegistrationMetadataResponse,
+    ActivityRegistrationMetadataUpdate,
+    ActivityRegistrationResponse,
+    ActivityRegistrationSlotsResponse,
+)
+
+__all__ = [
+    "ActivityRegistrationMetadataResponse",
+    "ActivityRegistrationMetadataUpdate",
+    "ActivityRegistrationResponse",
+    "ActivityRegistrationSlotsResponse",
+]

--- a/schemas/activity_registration.py
+++ b/schemas/activity_registration.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class ActivityRegistrationMetadataUpdate(BaseModel):
+    is_restricted: bool = False
+    slots: int | None = None
+
+
+class ActivityRegistrationMetadataResponse(BaseModel):
+    activity_id: int
+    is_restricted: bool
+    slots: int | None = None
+
+    class Config:
+        from_attributes = True
+
+
+class ActivityRegistrationResponse(BaseModel):
+    id: int
+    activity_id: int
+    user_id: str
+    created_at: datetime | None = None
+
+    class Config:
+        from_attributes = True
+
+
+class ActivityRegistrationSlotsResponse(BaseModel):
+    activity_id: int
+    slots: int | None = None
+    registered: int
+    available: int | None = None
+    is_restricted: bool

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,3 @@
+from .activity_registration_service import ActivityRegistrationService
+
+__all__ = ["ActivityRegistrationService"]

--- a/services/activity_registration_service.py
+++ b/services/activity_registration_service.py
@@ -1,0 +1,145 @@
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from coffeebreak.auth import is_anonymous
+from coffeebreak.models import ActivityModel
+
+from ..models import ActivityRegistration, ActivityRegistrationMetadata
+from ..schemas import (
+    ActivityRegistrationMetadataResponse,
+    ActivityRegistrationResponse,
+    ActivityRegistrationSlotsResponse,
+)
+
+
+class ActivityRegistrationService:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def get_metadata(self, activity_id: int) -> ActivityRegistrationMetadataResponse:
+        self._ensure_activity_exists(activity_id)
+        metadata = self._get_metadata_record(activity_id)
+        if metadata:
+            return ActivityRegistrationMetadataResponse.model_validate(metadata)
+        return ActivityRegistrationMetadataResponse(
+            activity_id=activity_id, is_restricted=False, slots=None
+        )
+
+    def upsert_metadata(
+        self, activity_id: int, is_restricted: bool, slots: int | None
+    ) -> ActivityRegistrationMetadataResponse:
+        self._ensure_activity_exists(activity_id)
+        self._validate_metadata(is_restricted, slots)
+
+        metadata = self._get_metadata_record(activity_id)
+        if not metadata:
+            metadata = ActivityRegistrationMetadata(activity_id=activity_id)
+            self.db.add(metadata)
+
+        metadata.is_restricted = is_restricted
+        metadata.slots = slots
+        self.db.commit()
+        self.db.refresh(metadata)
+
+        return ActivityRegistrationMetadataResponse.model_validate(metadata)
+
+    def register(
+        self, activity_id: int, user: dict | None, force_auth: bool = True
+    ) -> ActivityRegistrationResponse:
+        self._ensure_activity_exists(activity_id)
+
+        if force_auth and (not user or is_anonymous(user)):
+            raise HTTPException(status_code=401, detail="Authentication required")
+
+        user_id = self._get_user_id(user)
+        if not user_id:
+            raise HTTPException(status_code=401, detail="Authentication required")
+
+        existing = (
+            self.db.query(ActivityRegistration)
+            .filter_by(activity_id=activity_id, user_id=user_id)
+            .first()
+        )
+        if existing:
+            raise HTTPException(
+                status_code=409, detail="User already registered for this activity"
+            )
+
+        metadata = self._get_metadata_record(activity_id)
+        if metadata and metadata.is_restricted:
+            if metadata.slots is None:
+                raise HTTPException(
+                    status_code=400, detail="Restricted activities must define slots"
+                )
+
+            registered = self._count_registered(activity_id)
+            if registered >= metadata.slots:
+                raise HTTPException(
+                    status_code=409, detail="No available slots for this activity"
+                )
+
+        registration = ActivityRegistration(activity_id=activity_id, user_id=user_id)
+        self.db.add(registration)
+        self.db.commit()
+        self.db.refresh(registration)
+
+        return ActivityRegistrationResponse.model_validate(registration)
+
+    def get_available_slots(
+        self, activity_id: int
+    ) -> ActivityRegistrationSlotsResponse:
+        self._ensure_activity_exists(activity_id)
+
+        metadata = self._get_metadata_record(activity_id)
+        is_restricted = metadata.is_restricted if metadata else False
+        slots = metadata.slots if metadata else None
+        registered = self._count_registered(activity_id)
+        available = (
+            max(slots - registered, 0) if is_restricted and slots is not None else None
+        )
+
+        return ActivityRegistrationSlotsResponse(
+            activity_id=activity_id,
+            slots=slots,
+            registered=registered,
+            available=available,
+            is_restricted=is_restricted,
+        )
+
+    def _ensure_activity_exists(self, activity_id: int) -> None:
+        activity = (
+            self.db.query(ActivityModel).filter(ActivityModel.id == activity_id).first()
+        )
+        if not activity:
+            raise HTTPException(status_code=404, detail="Activity not found")
+
+    def _get_metadata_record(
+        self, activity_id: int
+    ) -> ActivityRegistrationMetadata | None:
+        return (
+            self.db.query(ActivityRegistrationMetadata)
+            .filter_by(activity_id=activity_id)
+            .first()
+        )
+
+    def _count_registered(self, activity_id: int) -> int:
+        return (
+            self.db.query(ActivityRegistration)
+            .filter_by(activity_id=activity_id)
+            .count()
+        )
+
+    def _get_user_id(self, user: dict | None) -> str | None:
+        if not user:
+            return None
+        return user.get("sub")
+
+    def _validate_metadata(self, is_restricted: bool, slots: int | None) -> None:
+        if slots is not None and slots < 0:
+            raise HTTPException(
+                status_code=400, detail="Slots must be greater than or equal to 0"
+            )
+        if is_restricted and slots is None:
+            raise HTTPException(
+                status_code=400, detail="Slots are required when activity is restricted"
+            )


### PR DESCRIPTION
## Summary

- **admin/Page.jsx**: self-contained component using coffeebreak SDK with its own i18n namespace (`registration-system-plugin`)
- **locales/**: add `en.json`, `pt-BR.json`, `pt-PT.json` with activity slots translations
- **backend**: full plugin backend implementation (`__init__.py`, `models/`, `router/`, `schemas/`, `services/`)
- **.build/**: compiled frontend bundles